### PR TITLE
Add async button

### DIFF
--- a/Shared/ContentView.swift
+++ b/Shared/ContentView.swift
@@ -15,7 +15,8 @@ let threshold_key = try! ThresholdKey(
     storage_layer: storage_layer,
     service_provider: service_provider,
     enable_logging: true,
-    manual_sync: false)
+    manual_sync: false
+)
 
 var logs: [String] = []
 
@@ -51,12 +52,455 @@ struct ThirdTabView: View {
     @State private var finalKey = ""
     @State private var shareIndexCreated = ""
     @State private var phrase = ""
-    let semaphore = DispatchSemaphore(value: 1)
 
 
     func logger(data: String) {
         logs.append(data + "\n")
     }
+    
+    public func createNewTkeyButton() -> some View{
+        HStack {
+            Text("Create new tkey")
+            Spacer()
+            Button(action: {
+                isLoading = true
+                let key_details = try! threshold_key.initialize(never_initialize_new_key: false, include_local_metadata_transitions: false)
+                let key = try! threshold_key.reconstruct()
+                // print(key_details.pub_key, key_details.required_shares)
+                totalShares = Int(key_details.total_shares)
+                threshold = Int(key_details.threshold)
+                finalKey = key.key
+
+                alertContent = "\(totalShares) shares created"
+                logger(data: alertContent.description)
+                isLoading = false
+                showAlert = true
+            }) {
+                Text("")
+            } .alert(isPresented: $showAlert) {
+                Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
+            }
+        }
+    }
+    
+    public func createTkeyAsyncButton() -> some View{
+        HStack {
+            Text("Create new tkey async")
+            Spacer()
+            Button(action: {
+                DispatchQueue.global().async {
+                    self.isLoading = true
+                    threshold_key.initializeAsync(never_initialize_new_key: false, include_local_metadata_transitions: false) { result in
+                        switch result {
+                        case .success(let keyDetails):
+                            self.totalShares = Int(keyDetails.total_shares)
+                            self.threshold = Int(keyDetails.threshold)
+                            threshold_key.reconstructAsync { result in
+                                switch result {
+                                case .success(let keyReconstructionDetails):
+                                    self.finalKey = keyReconstructionDetails.key
+                                    self.alertContent = "\(self.totalShares) shares created"
+                                    self.logger(data: self.alertContent.description)
+                                    self.isLoading = false
+                                    DispatchQueue.main.async {
+                                        self.showAlert = true
+                                    }
+                                case .failure(let error):
+                                    print(error)
+                                }
+                            }
+                        case .failure(let error):
+                            print(error)
+                        }
+                    }
+                }
+            }) {
+                Text("")
+            }.alert(isPresented: $showAlert) {
+                Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Dismiss")))
+            }
+        }
+    }
+    
+    public func reconstructKeyButton() -> some View {
+        HStack {
+            Text("Reconstruct key")
+            Spacer()
+            Button(action: {
+                let key = try! threshold_key.reconstruct()
+                finalKey = key.key
+                alertContent = "\(key.key) is the final private key"
+                logger(data: alertContent.description)
+                showAlert = true
+            }) {
+                Text("")
+            } .alert(isPresented: $showAlert) {
+                Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
+            }
+        }
+    }
+    
+    public func getKeyDetailButton() -> some View {
+        HStack {
+            Text("Get key details")
+            Spacer()
+            Button(action: {
+                let key_details = try! threshold_key.get_key_details()
+                totalShares = Int(key_details.total_shares)
+                threshold = Int(key_details.threshold)
+                alertContent = "You have \(totalShares) shares. \(key_details.required_shares) are required to reconstruct the final key"
+                logger(data: alertContent.description)
+                showAlert = true
+            }) {
+                Text("")
+            } .alert(isPresented: $showAlert) {
+                Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
+            }
+        }
+    }
+    
+    public func generateNewShareButton() -> some View {
+        HStack {
+            Text("Generate new share async")
+            Spacer()
+            Button(action: {
+                threshold_key.generateNewShareAsync(){ result in
+                    switch result {
+                        case .success(let share):
+                            let index = share.hex
+                            threshold_key.getKeyDetailsAsync(){ result in
+                                switch result {
+                                    case .success(let key_details):
+                                        totalShares = Int(key_details.total_shares)
+                                        threshold = Int(key_details.threshold)
+                                        shareIndexCreated = index
+                                        alertContent = "You have \(totalShares) shares. New share with index, \(index) was created"
+                                        logger(data: alertContent.description)
+                                        showAlert = true
+                                    case .failure(let err):
+                                        print(err)
+                                }
+                            }
+                        case .failure(let err):
+                            print(err)
+                    }
+                }
+            }) {
+                Text("")
+            } .alert(isPresented: $showAlert) {
+                Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
+            }
+        }
+    }
+    
+    public func deleteShareButton() -> some View {
+        HStack {
+            Text("Delete share")
+            Spacer()
+            Button(action: {
+                try! threshold_key.delete_share(share_index: shareIndexCreated )
+                let key_details = try! threshold_key.get_key_details()
+                totalShares = Int(key_details.total_shares)
+                threshold = Int(key_details.threshold)
+                alertContent = "You have \(totalShares) shares. Share index, \(shareIndexCreated) was deleted"
+                logger(data: alertContent.description)
+                showAlert = true
+            }) {
+                Text("")
+            } .alert(isPresented: $showAlert) {
+                Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
+            }
+        }
+    }
+    
+    public func AddPasswordButton() -> some View {
+        HStack {
+            Text("Add password")
+            Spacer()
+            Button(action: {
+                let question = "what's your password?"
+                let answer = "blublu"
+
+                do {
+                    let share = try SecurityQuestionModule.generate_new_share(threshold_key: threshold_key, questions: question, answer: answer)
+                    print(share.share_store, share.hex)
+
+                    let key_details = try! threshold_key.get_key_details()
+                    totalShares = Int(key_details.total_shares)
+                    threshold = Int(key_details.threshold)
+
+                    alertContent = "New password share created with password: \(answer)"
+                    logger(data: alertContent.description)
+                    showAlert = true
+                } catch {
+                    alertContent = "Password share already exists"
+                    logger(data: alertContent.description)
+                    showAlert = true
+                }
+            }) {
+                Text("")
+            } .alert(isPresented: $showAlert) {
+                Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
+            }
+        }
+    }
+    
+    public func AddPasswordAsyncButton() -> some View {
+        HStack {
+            Text("Add password async")
+            Spacer()
+            Button(action: {
+                let question = "what's your password?"
+                let answer = "blublu"
+
+                SecurityQuestionModule.generateNewShareAsync(threshold_key: threshold_key, questions: question, answer: answer) { result in
+                    switch result {
+                    case .success(let share):
+                        print("here success")
+                        print(share.share_store, share.hex)
+                        threshold_key.getKeyDetailsAsync() { result in
+                            switch result {
+                            case .success(let KeyDetails):
+                                self.totalShares = Int(KeyDetails.total_shares)
+                                self.threshold = Int(KeyDetails.threshold)
+
+                                alertContent = "New password share created with password: \(answer)"
+                                DispatchQueue.main.async {
+                                    self.showAlert = true
+                                }
+                            case .failure(let error):
+                                alertContent = "get key details failed"
+                                showAlert = true
+                                print(error)
+                            }
+                        }
+                    case .failure(let error):
+                        print("here faliure")
+
+                        alertContent = "Password share already exists"
+                        logger(data: alertContent.description)
+                        showAlert = true
+                        print(error)
+                    }
+                }
+                
+            }) {
+                Text("")
+            } .alert(isPresented: $showAlert) {
+                Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
+            }
+        }
+    }
+    
+    public func ChangePasswordButton() -> some View {
+        HStack {
+            Text("Change password")
+            Spacer()
+            Button(action: {
+                let question = "what's your password?"
+                let answer = "blublublu"
+                try! SecurityQuestionModule.change_question_and_answer(threshold_key: threshold_key, questions: question, answer: answer)
+                let key_details = try! threshold_key.get_key_details()
+                totalShares = Int(key_details.total_shares)
+                threshold = Int(key_details.threshold)
+
+                alertContent = "Password changed to: \(answer)"
+                logger(data: alertContent.description)
+                showAlert = true
+            }) {
+                Text("")
+            } .alert(isPresented: $showAlert) {
+                Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
+            }
+        }
+    }
+    
+    public func ShowPasswordButton() -> some View {
+        HStack {
+            Text("Show password")
+            Spacer()
+            Button(action: {
+                let data = try! SecurityQuestionModule.get_answer(threshold_key: threshold_key)
+                let key_details = try! threshold_key.get_key_details()
+                totalShares = Int(key_details.total_shares)
+                threshold = Int(key_details.threshold)
+
+                alertContent = "Password is: \(data)"
+                logger(data: alertContent.description)
+                showAlert = true
+            }) {
+                Text("")
+            } .alert(isPresented: $showAlert) {
+                Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
+            }
+        }
+    }
+    
+    public func SetSeedPhraseButton() -> some View {
+        HStack {
+            Text("Set seed pharse")
+            Spacer()
+            Button(action: {
+                let seedPhraseToSet = "seed sock milk update focus rotate barely fade car face mechanic mercy"
+
+                try! SeedPhraseModule.set_seed_phrase(threshold_key: threshold_key, format: "HD Key Tree", phrase: seedPhraseToSet, number_of_wallets: 0)
+
+                phrase = seedPhraseToSet
+                alertContent = "set seed phrase complete"
+                showAlert = true
+            }) {
+                Text("")
+            }.alert(isPresented: $showAlert) {
+                Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
+            }
+        }
+    }
+
+    public func GetSeedPhraseButton() -> some View {
+        HStack {
+            Text("Get seed pharse")
+            Spacer()
+            Button(action: {
+
+                let seedResult = try!
+                    SeedPhraseModule
+                    .get_seed_phrases(threshold_key: threshold_key)
+                // TODO : get string result from seedResult
+                print("result", seedResult)
+                alertContent = "seed phrase is `\(seedResult[0].seedPhrase)`"
+
+                showAlert = true
+            }) {
+                Text("")
+            }.alert(isPresented: $showAlert) {
+                Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
+            }
+        }
+    }
+
+    public func ChangeSeedPhraseButton() -> some View {
+        HStack {
+            Text("Change seed pharse")
+            Spacer()
+            Button(action: {
+                let seedPhraseToChange = "object brass success calm lizard science syrup planet exercise parade honey impulse"
+
+                try! SeedPhraseModule.change_phrase(threshold_key: threshold_key, old_phrase: "seed sock milk update focus rotate barely fade car face mechanic mercy", new_phrase: seedPhraseToChange)
+                phrase = seedPhraseToChange
+                alertContent = "change seed phrase complete"
+                showAlert = true
+            }) {
+                Text("")
+            }.alert(isPresented: $showAlert) {
+                Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
+            }
+        }
+    }
+
+    public func DeleteSeedPhraseButton() -> some View {
+        HStack {
+            Text("Delete Seed phrase")
+            Spacer()
+            Button(action: {
+                try!
+                SeedPhraseModule
+                    .delete_seedphrase(threshold_key: threshold_key, phrase: phrase)
+
+                phrase = ""
+                alertContent = "delete seed phrase complete"
+
+                showAlert = true
+            }) {
+                Text("")
+            }.alert(isPresented: $showAlert) {
+                Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
+            }
+        }
+    }
+    
+    public func ExportShareButton() -> some View {
+        HStack {
+            Text("Export share")
+            Spacer()
+            Button(action: {
+                let shareStore = try! threshold_key.generate_new_share()
+                let index = shareStore.hex
+
+                let key_details = try! threshold_key.get_key_details()
+                totalShares = Int(key_details.total_shares)
+                threshold = Int(key_details.threshold)
+                shareIndexCreated = index
+
+                let shareOut = try! threshold_key.output_share(shareIndex: index, shareType: nil)
+
+                let result = try! ShareSerializationModule.serialize_share(threshold_key: threshold_key, share: shareOut, format: nil)
+                alertContent = "serialize result is \(result)"
+                showAlert = true
+            }) {
+                Text("")
+            }.alert(isPresented: $showAlert) {
+                Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
+            }
+        }
+    }
+
+    public func SetPrivateKeyButton() -> some View {
+        HStack {
+            Text("Set Private Key")
+            Spacer()
+            Button(action: {
+                let key_module = try! PrivateKey.generate()
+
+                let result = try! PrivateKeysModule.set_private_key(threshold_key: threshold_key, key: key_module.hex, format: "secp256k1n")
+                if result {
+                    alertContent = "setting private key completed"
+                } else {
+                    alertContent = "Setting private key failed"
+                }
+                showAlert = true
+            }) {
+                Text("")
+            }.alert(isPresented: $showAlert) {
+                Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
+            }
+        }
+    }
+    
+    public func GetPrivateKeyButton() -> some View {
+        HStack {
+            Text("Get Private Key")
+            Spacer()
+            Button(action: {
+                let result = try! PrivateKeysModule.get_private_keys(threshold_key: threshold_key)
+
+                alertContent = "Get private key result is \(result)"
+                showAlert = true
+            }) {
+                Text("")
+            }.alert(isPresented: $showAlert) {
+                Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
+            }
+        }
+    }
+    
+    public func GetAccountButton() -> some View {
+        HStack {
+            Text("Get Accounts")
+            Spacer()
+            Button(action: {
+                let result = try! PrivateKeysModule.get_private_key_accounts(threshold_key: threshold_key)
+
+                alertContent = "Get accounts result is \(result)"
+                showAlert = true
+            }) {
+                Text("")
+            }.alert(isPresented: $showAlert) {
+                Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
+            }
+        }
+    }
+    
+
 
     var body: some View {
         VStack {
@@ -78,437 +522,54 @@ struct ThirdTabView: View {
             .padding()
             List {
                 Section(header: Text("Basic functionality")) {
-                    HStack {
-                        Text("Create new tkey")
-                        Spacer()
-                        Button(action: {
-                            isLoading = true
-                            let key_details = try! threshold_key.initialize(never_initialize_new_key: false, include_local_metadata_transitions: false)
-                            let key = try! threshold_key.reconstruct()
-                            // print(key_details.pub_key, key_details.required_shares)
-                            totalShares = Int(key_details.total_shares)
-                            threshold = Int(key_details.threshold)
-                            finalKey = key.key
-
-                            alertContent = "\(totalShares) shares created"
-                            logger(data: alertContent.description)
-                            isLoading = false
-                            showAlert = true
-                        }) {
-                            Text("")
-                        } .alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
-                        }
-                    }
-                    HStack {
-                        Text("Create new tkey async")
-                        Spacer()
-                        Button(action: {
-                            DispatchQueue.global().async {
-                                self.isLoading = true
-                                threshold_key.initializeAsync(never_initialize_new_key: false, include_local_metadata_transitions: false) { result in
-                                    switch result {
-                                    case .success(let keyDetails):
-                                        self.totalShares = Int(keyDetails.total_shares)
-                                        self.threshold = Int(keyDetails.threshold)
-                                        threshold_key.reconstructAsync { result in
-                                            switch result {
-                                            case .success(let keyReconstructionDetails):
-                                                self.finalKey = keyReconstructionDetails.key
-                                                self.alertContent = "\(self.totalShares) shares created"
-                                                self.logger(data: self.alertContent.description)
-                                                self.isLoading = false
-                                                DispatchQueue.main.async {
-                                                    self.showAlert = true
-                                                }
-                                            case .failure(let error):
-                                                print(error)
-                                            }
-                                        }
-                                    case .failure(let error):
-                                        print(error)
-                                    }
-                                }
-                            }
-                        }) {
-                            Text("")
-                        }.alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Dismiss")))
-                        }
-                    }
-                    HStack {
-                        Text("Reconstruct key")
-                        Spacer()
-                        Button(action: {
-                            let key = try! threshold_key.reconstruct()
-                            finalKey = key.key
-                            alertContent = "\(key.key) is the final private key"
-                            logger(data: alertContent.description)
-                            showAlert = true
-                        }) {
-                            Text("")
-                        } .alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
-                        }
-                    }
-
-                    HStack {
-                        Text("Get key details")
-                        Spacer()
-                        Button(action: {
-                            let key_details = try! threshold_key.get_key_details()
-                            totalShares = Int(key_details.total_shares)
-                            threshold = Int(key_details.threshold)
-                            alertContent = "You have \(totalShares) shares. \(key_details.required_shares) are required to reconstruct the final key"
-                            logger(data: alertContent.description)
-                            showAlert = true
-                        }) {
-                            Text("")
-                        } .alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
-                        }
-                    }
-
-                    HStack {
-                        Text("Generate new share")
-                        Spacer()
-                        Button(action: {
-                            let shares = try! threshold_key.generate_new_share()
-                            let index = shares.hex
-
-                            let key_details = try! threshold_key.get_key_details()
-                            totalShares = Int(key_details.total_shares)
-                            threshold = Int(key_details.threshold)
-                            shareIndexCreated = index
-                            alertContent = "You have \(totalShares) shares. New share with index, \(index) was created"
-                            logger(data: alertContent.description)
-                            showAlert = true
-                        }) {
-                            Text("")
-                        } .alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
-                        }
-                    }
                     
-                    HStack {
-                        Text("Generate new share async")
-                        Spacer()
-                        Button(action: {
-                            threshold_key.generateNewShareAsync(){ result in
-                                switch result {
-                                    case .success(let share):
-                                        let index = share.hex
-                                        threshold_key.getKeyDetailsAsync(){ result in
-                                            switch result {
-                                                case .success(let key_details):
-                                                    totalShares = Int(key_details.total_shares)
-                                                    threshold = Int(key_details.threshold)
-                                                    shareIndexCreated = index
-                                                    alertContent = "You have \(totalShares) shares. New share with index, \(index) was created"
-                                                    logger(data: alertContent.description)
-                                                    showAlert = true
-                                                case .failure(let err):
-                                                    print(err)
-                                            }
-                                        }
-                                    case .failure(let err):
-                                        print(err)
-                                }
-                            }
-                        }) {
-                            Text("")
-                        } .alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
-                        }
+                    createNewTkeyButton()
+                    
+                    createTkeyAsyncButton()
+                    
+                    reconstructKeyButton()
 
-                    }
+                    getKeyDetailButton()
 
-                    HStack {
-                        Text("Delete share")
-                        Spacer()
-                        Button(action: {
-                            try! threshold_key.delete_share(share_index: shareIndexCreated )
-                            let key_details = try! threshold_key.get_key_details()
-                            totalShares = Int(key_details.total_shares)
-                            threshold = Int(key_details.threshold)
-                            alertContent = "You have \(totalShares) shares. Share index, \(shareIndexCreated) was deleted"
-                            logger(data: alertContent.description)
-                            showAlert = true
-                        }) {
-                            Text("")
-                        } .alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
-                        }
-                    }
+                    generateNewShareButton()
+                    
+                    deleteShareButton()
 
                 }
 
                 // MARK: Security questions or password
                 Section(header: Text("Security Question")) {
-                    HStack {
-                        Text("Add password")
-                        Spacer()
-                        Button(action: {
-                            let question = "what's your password?"
-                            let answer = "blublu"
-
-                            do {
-                                let share = try SecurityQuestionModule.generate_new_share(threshold_key: threshold_key, questions: question, answer: answer)
-                                print(share.share_store, share.hex)
-
-                                let key_details = try! threshold_key.get_key_details()
-                                totalShares = Int(key_details.total_shares)
-                                threshold = Int(key_details.threshold)
-
-                                alertContent = "New password share created with password: \(answer)"
-                                logger(data: alertContent.description)
-                                showAlert = true
-                            } catch {
-                                alertContent = "Password share already exists"
-                                logger(data: alertContent.description)
-                                showAlert = true
-                            }
-                        }) {
-                            Text("")
-                        } .alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
-                        }
-                    }
                     
-                    HStack {
-                        Text("Add password async")
-                        Spacer()
-                        Button(action: {
-                            let question = "what's your password?"
-                            let answer = "blublu"
+                    AddPasswordButton()
+                    
+                    AddPasswordAsyncButton()
 
-                            DispatchQueue.main.async {
-                                SecurityQuestionModule.generateNewShareAsync(threshold_key: threshold_key, questions: question, answer: answer) { result in
-                                    switch result {
-                                    case .success(let share):
-                                        print(share.share_store, share.hex)
-                                        threshold_key.getKeyDetailsAsync() { result in
-                                            switch result {
-                                            case .success(let KeyDetails):
-                                                self.totalShares = Int(KeyDetails.total_shares)
-                                                self.threshold = Int(KeyDetails.threshold)
+                    ChangePasswordButton()
+                    
+                    ShowPasswordButton()
 
-                                                alertContent = "New password share created with password: \(answer)"
-                                                DispatchQueue.main.async {
-                                                    self.showAlert = true
-                                                }
-                                            case .failure(let error):
-                                                alertContent = "get key details failed"
-                                                showAlert = true
-                                                print(error)
-                                            }
-                                        }
-                                    case .failure(let error):
-                                        alertContent = "Password share already exists"
-                                        logger(data: alertContent.description)
-                                        showAlert = true
-                                        print(error)
-                                    }
-                                }
-                            }
-                        }) {
-                            Text("")
-                        } .alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
-                        }
-                    }
-
-                    HStack {
-                        Text("Change password")
-                        Spacer()
-                        Button(action: {
-                            let question = "what's your password?"
-                            let answer = "blublublu"
-                            try! SecurityQuestionModule.change_question_and_answer(threshold_key: threshold_key, questions: question, answer: answer)
-                            let key_details = try! threshold_key.get_key_details()
-                            totalShares = Int(key_details.total_shares)
-                            threshold = Int(key_details.threshold)
-
-                            alertContent = "Password changed to: \(answer)"
-                            logger(data: alertContent.description)
-                            showAlert = true
-                        }) {
-                            Text("")
-                        } .alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
-                        }
-                    }
-
-                    HStack {
-                        Text("Show password")
-                        Spacer()
-                        Button(action: {
-                            let data = try! SecurityQuestionModule.get_answer(threshold_key: threshold_key)
-                            let key_details = try! threshold_key.get_key_details()
-                            totalShares = Int(key_details.total_shares)
-                            threshold = Int(key_details.threshold)
-
-                            alertContent = "Password is: \(data)"
-                            logger(data: alertContent.description)
-                            showAlert = true
-                        }) {
-                            Text("")
-                        } .alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
-                        }
-                    }
                 }
                 Section(header: Text("seed phrase")) {
-                    HStack {
-                        Text("Set seed pharse")
-                        Spacer()
-                        Button(action: {
-                            let seedPhraseToSet = "seed sock milk update focus rotate barely fade car face mechanic mercy"
+                    SetSeedPhraseButton()
+                    
+                    ChangeSeedPhraseButton()
 
-                            try! SeedPhraseModule.set_seed_phrase(threshold_key: threshold_key, format: "HD Key Tree", phrase: seedPhraseToSet, number_of_wallets: 0)
-
-                            phrase = seedPhraseToSet
-                            alertContent = "set seed phrase complete"
-                            showAlert = true
-                        }) {
-                            Text("")
-                        }.alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
-                        }
-                    }
-
-                    HStack {
-                        Text("Change seed pharse")
-                        Spacer()
-                        Button(action: {
-                            let seedPhraseToChange = "object brass success calm lizard science syrup planet exercise parade honey impulse"
-
-                            try! SeedPhraseModule.change_phrase(threshold_key: threshold_key, old_phrase: "seed sock milk update focus rotate barely fade car face mechanic mercy", new_phrase: seedPhraseToChange)
-                            phrase = seedPhraseToChange
-                            alertContent = "change seed phrase complete"
-                            showAlert = true
-                        }) {
-                            Text("")
-                        }.alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
-                        }
-                    }
-
-                    HStack {
-                        Text("Get seed pharse")
-                        Spacer()
-                        Button(action: {
-
-                            let seedResult = try!
-                                SeedPhraseModule
-                                .get_seed_phrases(threshold_key: threshold_key)
-                            // TODO : get string result from seedResult
-                            print("result", seedResult)
-                            alertContent = "seed phrase is `\(seedResult[0].seedPhrase)`"
-
-                            showAlert = true
-                        }) {
-                            Text("")
-                        }.alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
-                        }
-                    }
-
-                    HStack {
-                        Text("Delete Seed phrase")
-                        Spacer()
-                        Button(action: {
-                            try!
-                            SeedPhraseModule
-                                .delete_seedphrase(threshold_key: threshold_key, phrase: phrase)
-
-                            phrase = ""
-                            alertContent = "delete seed phrase complete"
-
-                            showAlert = true
-                        }) {
-                            Text("")
-                        }.alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
-                        }
-                    }
+                    GetSeedPhraseButton()
+                    
+                    DeleteSeedPhraseButton()
+                
                 }
                 Section(header: Text("Share Serialization")) {
-                    HStack {
-                        Text("Export share")
-                        Spacer()
-                        Button(action: {
-                            let shareStore = try! threshold_key.generate_new_share()
-                            let index = shareStore.hex
-
-                            let key_details = try! threshold_key.get_key_details()
-                            totalShares = Int(key_details.total_shares)
-                            threshold = Int(key_details.threshold)
-                            shareIndexCreated = index
-
-                            let shareOut = try! threshold_key.output_share(shareIndex: index, shareType: nil)
-
-                            let result = try! ShareSerializationModule.serialize_share(threshold_key: threshold_key, share: shareOut, format: nil)
-                            alertContent = "serialize result is \(result)"
-                            showAlert = true
-                        }) {
-                            Text("")
-                        }.alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
-                        }
-                    }
+                    ExportShareButton()
                 }
 
                 Section(header: Text("Private Key")) {
-                    HStack {
-                        Text("Set Private Key")
-                        Spacer()
-                        Button(action: {
-                            let key_module = try! PrivateKey.generate()
-
-                            let result = try! PrivateKeysModule.set_private_key(threshold_key: threshold_key, key: key_module.hex, format: "secp256k1n")
-                            if result {
-                                alertContent = "setting private key completed"
-                            } else {
-                                alertContent = "Setting private key failed"
-                            }
-                            showAlert = true
-                        }) {
-                            Text("")
-                        }.alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
-                        }
-                    }
-
-                    HStack {
-                        Text("Get Private Key")
-                        Spacer()
-                        Button(action: {
-                            let result = try! PrivateKeysModule.get_private_keys(threshold_key: threshold_key)
-
-                            alertContent = "Get private key result is \(result)"
-                            showAlert = true
-                        }) {
-                            Text("")
-                        }.alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
-                        }
-                    }
-
-                    HStack {
-                        Text("Get Accounts")
-                        Spacer()
-                        Button(action: {
-                            let result = try! PrivateKeysModule.get_private_key_accounts(threshold_key: threshold_key)
-
-                            alertContent = "Get accounts result is \(result)"
-                            showAlert = true
-                        }) {
-                            Text("")
-                        }.alert(isPresented: $showAlert) {
-                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
-                        }
-                    }
+                    
+                    SetPrivateKeyButton()
+                    
+                    GetPrivateKeyButton()
+                    
+                    GetAccountButton()
                 }
             }
         }

--- a/Shared/ContentView.swift
+++ b/Shared/ContentView.swift
@@ -102,8 +102,8 @@ struct ThirdTabView: View {
                         Text("Create new tkey async")
                         Spacer()
                         Button(action: {
-                            self.isLoading = true
                             DispatchQueue.global().async {
+                                self.isLoading = true
                                 threshold_key.initializeAsync(never_initialize_new_key: false, include_local_metadata_transitions: false) { result in
                                     switch result {
                                     case .success(let keyDetails):
@@ -181,6 +181,39 @@ struct ThirdTabView: View {
                             alertContent = "You have \(totalShares) shares. New share with index, \(index) was created"
                             logger(data: alertContent.description)
                             showAlert = true
+                        }) {
+                            Text("")
+                        } .alert(isPresented: $showAlert) {
+                            Alert(title: Text("Alert"), message: Text(alertContent), dismissButton: .default(Text("Ok")))
+                        }
+                    }
+                    
+                    HStack {
+                        Text("Generate new share async")
+                        Spacer()
+                        Button(action: {
+                            DispatchQueue.global().async {
+                                threshold_key.generateNewShareAsync(){ result in
+                                    switch result {
+                                        case .success(let share):
+                                            let index = share.hex
+                                            threshold_key.getKeyDetailsAsync(){ result in
+                                                switch result {
+                                                case .success(let key_details):
+                                                    totalShares = Int(key_details.total_shares)
+                                                    threshold = Int(key_details.threshold)
+                                                    shareIndexCreated = index
+                                                    alertContent = "You have \(totalShares) shares. New share with index, \(index) was created"
+                                                    logger(data: alertContent.description)
+                                                    self.showAlert = true
+                                                case .failure(let err):
+                                                    print(err)
+                                                }
+                                            }
+                                        case .failure(let err):
+                                    }
+                                }
+                            }
                         }) {
                             Text("")
                         } .alert(isPresented: $showAlert) {

--- a/Tests iOS/Tests_iOS.swift
+++ b/Tests iOS/Tests_iOS.swift
@@ -7,9 +7,49 @@
 
 import XCTest
 import tkey_ios
+import SwiftUI
+import tkey_pkg
+
 
 class ThresholdKey_Test: XCTestCase {
+    
 
-    func testExample() {
+    func testCreateTkeyAsyncButton() {
+        
+        let view = CreateTkeyAsyncButton(threshold_key: threshold_key)
+        let host = UIHostingController(rootView: view)
+
+        // Access the root view and the button from the view hierarchy
+        let rootView = host.view
+        let createTkeyAsyncButton = rootView.subviews.first(where: { $0 is UIButton }) as! UIButton
+
+        // Verify that the button is not currently in a loading state
+        XCTAssertFalse(view.isLoading)
+
+        // Simulate a tap on the button
+        createTkeyAsyncButton.sendActions(for: .touchUpInside)
+
+        // Verify that the button is now in a loading state
+        XCTAssertTrue(view.isLoading)
+
+        // Wait for the asynchronous call to complete
+        let expectation = self.expectation(description: "Wait for threshold_key.initializeAsync to complete")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+
+        // Verify that the totalShares and threshold properties were updated correctly
+        XCTAssertGreaterThan(view.totalShares, 0)
+        XCTAssertGreaterThan(view.threshold, 0)
+
+        // Verify that the alertContent property was updated correctly
+        XCTAssertEqual(view.alertContent, "\(view.totalShares) shares created")
+
+        // Verify that the button is no longer in a loading state
+        XCTAssertFalse(view.isLoading)
+
+        // Verify that the showAlert property is now true
+        XCTAssertTrue(view.showAlert)
     }
 }

--- a/tkey_ios.xcodeproj/project.pbxproj
+++ b/tkey_ios.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		14CC981E29891C340047113D /* ThresholdKey in Frameworks */ = {isa = PBXBuildFile; productRef = 14CC981D29891C340047113D /* ThresholdKey */; };
 		B30B6B2928BCC8AC00812C1E /* Tests_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30B6B2828BCC8AC00812C1E /* Tests_iOS.swift */; };
 		B30B6B2B28BCC8AC00812C1E /* Tests_iOSLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30B6B2A28BCC8AC00812C1E /* Tests_iOSLaunchTests.swift */; };
 		B30B6B3528BCC8AC00812C1E /* Tests_macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30B6B3428BCC8AC00812C1E /* Tests_macOS.swift */; };
@@ -17,8 +18,6 @@
 		B30B6B3B28BCC8AC00812C1E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30B6B1128BCC8A900812C1E /* ContentView.swift */; };
 		B30B6B3C28BCC8AC00812C1E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B30B6B1228BCC8AC00812C1E /* Assets.xcassets */; };
 		B30B6B3D28BCC8AC00812C1E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B30B6B1228BCC8AC00812C1E /* Assets.xcassets */; };
-		B37E79AF296EA60700C5F3F4 /* ThresholdKey in Frameworks */ = {isa = PBXBuildFile; productRef = B37E79AE296EA60700C5F3F4 /* ThresholdKey */; };
-		B3A1F29D29667EC80066658F /* ThresholdKey in Frameworks */ = {isa = PBXBuildFile; productRef = B3A1F29C29667EC80066658F /* ThresholdKey */; };
 		DD694C2D29713D2B00B34585 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30B6B1128BCC8A900812C1E /* ContentView.swift */; };
 /* End PBXBuildFile section */
 
@@ -53,6 +52,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		14CC981A29891B660047113D /* tkey-rust-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "tkey-rust-ios"; path = "../tkey-rust-ios"; sourceTree = "<group>"; };
+		14CC981B29891BBF0047113D /* tkey-rust-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "tkey-rust-ios"; path = "../tkey-rust-ios"; sourceTree = "<group>"; };
 		B30B6B1028BCC8A900812C1E /* tkey_iosApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = tkey_iosApp.swift; sourceTree = "<group>"; };
 		B30B6B1128BCC8A900812C1E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		B30B6B1228BCC8AC00812C1E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -72,7 +73,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B3A1F29D29667EC80066658F /* ThresholdKey in Frameworks */,
+				14CC981E29891C340047113D /* ThresholdKey in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -87,7 +88,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B37E79AF296EA60700C5F3F4 /* ThresholdKey in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -101,9 +101,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		14CC981929891B660047113D /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				14CC981A29891B660047113D /* tkey-rust-ios */,
+				14CC981B29891BBF0047113D /* tkey-rust-ios */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
 		B30B6B0A28BCC8A900812C1E = {
 			isa = PBXGroup;
 			children = (
+				14CC981929891B660047113D /* Packages */,
 				B30B6B0F28BCC8A900812C1E /* Shared */,
 				B30B6B1E28BCC8AC00812C1E /* macOS */,
 				B30B6B2728BCC8AC00812C1E /* Tests iOS */,
@@ -185,7 +195,7 @@
 			);
 			name = "tkey_ios (iOS)";
 			packageProductDependencies = (
-				B3A1F29C29667EC80066658F /* ThresholdKey */,
+				14CC981D29891C340047113D /* ThresholdKey */,
 			);
 			productName = "tkey_ios (iOS)";
 			productReference = B30B6B1728BCC8AC00812C1E /* tkey_ios.app */;
@@ -223,7 +233,6 @@
 			);
 			name = "Tests iOS";
 			packageProductDependencies = (
-				B37E79AE296EA60700C5F3F4 /* ThresholdKey */,
 			);
 			productName = "Tests iOS";
 			productReference = B30B6B2428BCC8AC00812C1E /* Tests iOS.xctest */;
@@ -287,7 +296,7 @@
 			);
 			mainGroup = B30B6B0A28BCC8A900812C1E;
 			packageReferences = (
-				B3A1F29B29667EC80066658F /* XCRemoteSwiftPackageReference "libtkey-pkg" */,
+				14CC981C29891C340047113D /* XCRemoteSwiftPackageReference "tkey-rust-ios" */,
 			);
 			productRefGroup = B30B6B1828BCC8AC00812C1E /* Products */;
 			projectDirPath = "";
@@ -835,9 +844,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		B3A1F29B29667EC80066658F /* XCRemoteSwiftPackageReference "libtkey-pkg" */ = {
+		14CC981C29891C340047113D /* XCRemoteSwiftPackageReference "tkey-rust-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/torusresearch/libtkey-pkg/";
+			repositoryURL = "https://github.com/torusresearch/tkey-rust-ios";
 			requirement = {
 				branch = feat/async;
 				kind = branch;
@@ -846,14 +855,9 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		B37E79AE296EA60700C5F3F4 /* ThresholdKey */ = {
+		14CC981D29891C340047113D /* ThresholdKey */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = B3A1F29B29667EC80066658F /* XCRemoteSwiftPackageReference "libtkey-pkg" */;
-			productName = ThresholdKey;
-		};
-		B3A1F29C29667EC80066658F /* ThresholdKey */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B3A1F29B29667EC80066658F /* XCRemoteSwiftPackageReference "libtkey-pkg" */;
+			package = 14CC981C29891C340047113D /* XCRemoteSwiftPackageReference "tkey-rust-ios" */;
 			productName = ThresholdKey;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/tkey_ios.xcodeproj/project.pbxproj
+++ b/tkey_ios.xcodeproj/project.pbxproj
@@ -839,7 +839,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/torusresearch/libtkey-pkg/";
 			requirement = {
-				branch = master;
+				branch = feat/async;
 				kind = branch;
 			};
 		};

--- a/tkey_ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/tkey_ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/torusresearch/libtkey-pkg/",
       "state" : {
         "branch" : "feat/async",
-        "revision" : "f19455cb41cceb924bae5e69c6cf214ae51c1d67"
+        "revision" : "8b62b73cbbd172b3d5059565b77c41d39880e435"
       }
     }
   ],

--- a/tkey_ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/tkey_ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/torusresearch/libtkey-pkg/",
       "state" : {
         "branch" : "feat/async",
-        "revision" : "ac7308c1f8b23d89c63e01cf8b02774de34b72f4"
+        "revision" : "f19455cb41cceb924bae5e69c6cf214ae51c1d67"
       }
     }
   ],

--- a/tkey_ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/tkey_ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "libtkey-pkg",
+      "identity" : "tkey-rust-ios",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/torusresearch/libtkey-pkg/",
+      "location" : "https://github.com/torusresearch/tkey-rust-ios",
       "state" : {
         "branch" : "feat/async",
-        "revision" : "8b62b73cbbd172b3d5059565b77c41d39880e435"
+        "revision" : "d099a25ec2a3fa5db516e77acfa17ac6ce535e92"
       }
     }
   ],

--- a/tkey_ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/tkey_ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/torusresearch/libtkey-pkg/",
       "state" : {
-        "branch" : "master",
-        "revision" : "5c0aa8d116c0967e3121dae012f45d03f0ce311c"
+        "branch" : "feat/async",
+        "revision" : "ac7308c1f8b23d89c63e01cf8b02774de34b72f4"
       }
     }
   ],


### PR DESCRIPTION
Added async function at
- Initialize
- Reconstruct
- Get key details
- generate new share
- securityquestion.generate_new_share

Based on this new async function, it was possible to make 2 async button, which are
- Create new tkey (async version)
- generate new share (Async version)
- Add password (async version, security question)

Those button does not block UX, which means if I click the button, we can move and manipulate screen.

related tkey rust ios PR : https://github.com/torusresearch/tkey-rust-ios/pull/7